### PR TITLE
Added persistent storage for config.json file

### DIFF
--- a/lnxd/github-backup.xml
+++ b/lnxd/github-backup.xml
@@ -14,7 +14,16 @@
   <Category>Backup:</Category>
   <Description>Like to maintain your own data? Automatically backup your github account to your Unraid server on a schedule.</Description>
   <TemplateURL>false</TemplateURL>
+  <Data>
+    <Volume>
+      <HostDir>/mnt/user/appdata/github-backup/</HostDir>
+      <ContainerDir>/home/docker/github-backup/config/</ContainerDir>
+      <Mode>rw</Mode>
+    </Volume>
+  </Data>
+ 
   <Config Name="Token" Target="TOKEN" Default="1a2b3c4d5e6f71a2b3c4d5e6f71a2b3c4d5e6f7b" Mode="" Description="Get your token from https://github.com/settings/tokens, see the support page for more details." Type="Variable" Display="always" Required="false" Mask="false">1a2b3c4d5e6f71a2b3c4d5e6f71a2b3c4d5e6f7b</Config>
   <Config Name="Schedule" Target="SCHEDULE" Default="3600" Mode="" Description="How often to sync in seconds (eg. 3600 for 1h, 21600 for 6h, 43200 for 12h, 86400 for 24h)" Type="Variable" Display="always" Required="false" Mask="false">3600</Config>
   <Config Name="Backup location" Target="/home/docker/backups" Default="/mnt/user/backup/github" Mode="rw" Description="Set the location of your github backups. Please note that the default will create a backup share if it does not exist and you don't change it." Type="Path" Display="always" Required="false" Mask="false">/mnt/user/backup/github</Config>
+  <Config Name="Config location" Target="/home/docker/github-backup/config/" Default="" Mode="rw" Description="Persistent storage for config.json" Type="Path" Display="advanced" Required="false" Mask="false">/mnt/user/appdata/github-backup/</Config>
 </Container>

--- a/lnxd/github-backup.xml
+++ b/lnxd/github-backup.xml
@@ -21,7 +21,6 @@
       <Mode>rw</Mode>
     </Volume>
   </Data>
- 
   <Config Name="Token" Target="TOKEN" Default="1a2b3c4d5e6f71a2b3c4d5e6f71a2b3c4d5e6f7b" Mode="" Description="Get your token from https://github.com/settings/tokens, see the support page for more details." Type="Variable" Display="always" Required="false" Mask="false">1a2b3c4d5e6f71a2b3c4d5e6f71a2b3c4d5e6f7b</Config>
   <Config Name="Schedule" Target="SCHEDULE" Default="3600" Mode="" Description="How often to sync in seconds (eg. 3600 for 1h, 21600 for 6h, 43200 for 12h, 86400 for 24h)" Type="Variable" Display="always" Required="false" Mask="false">3600</Config>
   <Config Name="Backup location" Target="/home/docker/backups" Default="/mnt/user/backup/github" Mode="rw" Description="Set the location of your github backups. Please note that the default will create a backup share if it does not exist and you don't change it." Type="Path" Display="always" Required="false" Mask="false">/mnt/user/backup/github</Config>


### PR DESCRIPTION
Missing the persistent storage for the config.json.  This allows for the owners config to be added to the config.json

The backup.sh talks about copying back the config.json to persistent storage, but that storage is not defined.